### PR TITLE
migration to address, lat, lng

### DIFF
--- a/db/migrate/20190220135934_address_lat_long.rb
+++ b/db/migrate/20190220135934_address_lat_long.rb
@@ -1,0 +1,9 @@
+class AddressLatLong < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :offices, :location, :string
+    remove_column :offices, :coordinates, :string
+    add_column :offices, :address, :string
+    add_column :offices, :lat, :float
+    add_column :offices, :long, :float
+  end
+end


### PR DESCRIPTION
@maticoto20 This should remove the "location" and "coordinates" columns, and add "address" (a string), "lat", and "lng" (floats)